### PR TITLE
Add snooze functionality to clock-out notifications

### DIFF
--- a/Shared/Managers/NotificationManager.swift
+++ b/Shared/Managers/NotificationManager.swift
@@ -9,7 +9,7 @@ import Foundation
 import UserNotifications
 
 @MainActor
-final class NotificationManager {
+final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 
     static let shared = NotificationManager()
 
@@ -18,12 +18,40 @@ final class NotificationManager {
     private enum Identifier {
         static let clockInReminderPrefix = "com.tsubuzaki.WorkingHour.clockInReminder"
         static let clockOutReminder = "com.tsubuzaki.WorkingHour.clockOutReminder"
+        static let clockOutSnoozeReminder = "com.tsubuzaki.WorkingHour.clockOutSnoozeReminder"
+    }
+
+    private enum Action {
+        static let snooze = "com.tsubuzaki.WorkingHour.action.snooze"
+    }
+
+    private enum Category {
+        static let clockOutReminder = "com.tsubuzaki.WorkingHour.category.clockOutReminder"
     }
 
     // Number of days into the future to schedule weekday reminders.
     private let schedulingWindowDays = 30
 
-    private init() {}
+    private override init() {
+        super.init()
+        center.delegate = self
+        registerCategories()
+    }
+
+    private func registerCategories() {
+        let snoozeAction = UNNotificationAction(
+            identifier: Action.snooze,
+            title: String(localized: "Notification.Snooze"),
+            options: []
+        )
+        let clockOutCategory = UNNotificationCategory(
+            identifier: Category.clockOutReminder,
+            actions: [snoozeAction],
+            intentIdentifiers: [],
+            options: []
+        )
+        center.setNotificationCategories([clockOutCategory])
+    }
 
     func requestAuthorization() async -> Bool {
         do {
@@ -100,6 +128,7 @@ final class NotificationManager {
         content.title = String(localized: "Notification.ClockOut.Title")
         content.body = String(localized: "Notification.ClockOut.Body")
         content.sound = .default
+        content.categoryIdentifier = Category.clockOutReminder
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
         let request = UNNotificationRequest(
@@ -113,6 +142,33 @@ final class NotificationManager {
 
     func cancelClockOutReminder() {
         center.removePendingNotificationRequests(withIdentifiers: [Identifier.clockOutReminder])
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        guard response.actionIdentifier == Action.snooze else { return }
+        await scheduleSnoozeReminder()
+    }
+
+    private func scheduleSnoozeReminder() async {
+        let content = UNMutableNotificationContent()
+        content.title = String(localized: "Notification.ClockOut.Title")
+        content.body = String(localized: "Notification.ClockOut.Body")
+        content.sound = .default
+        content.categoryIdentifier = Category.clockOutReminder
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1800, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: Identifier.clockOutSnoozeReminder,
+            content: content,
+            trigger: trigger
+        )
+
+        try? await center.add(request)
     }
 
     private func formatDateForIdentifier(_ date: Date) -> String {

--- a/Ushio/Bundle.swift
+++ b/Ushio/Bundle.swift
@@ -11,6 +11,7 @@ import SwiftUI
 @main
 struct UshioBundle: WidgetBundle {
     var body: some Widget {
+        UshioHomeWidget()
         UshioLiveActivity()
         StartWorkSessionControl()
         EndWorkSessionControl()

--- a/Ushio/Home Screen Widget/HomeWidget.swift
+++ b/Ushio/Home Screen Widget/HomeWidget.swift
@@ -1,0 +1,37 @@
+//
+//  HomeWidget.swift
+//  Ushio
+//
+//  Created by シン・ジャスティン on 2026/02/20.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct UshioHomeWidget: Widget {
+    let kind: String = "com.tsubuzaki.WorkingHour.Ushio.Home"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: HomeWidgetProvider()) { entry in
+            HomeWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Widget.DisplayName")
+        .description("Widget.Description")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+#Preview(as: .systemSmall) {
+    UshioHomeWidget()
+} timeline: {
+    HomeWidgetEntry.placeholder
+    HomeWidgetEntry.empty
+}
+
+#Preview(as: .systemMedium) {
+    UshioHomeWidget()
+} timeline: {
+    HomeWidgetEntry.placeholder
+    HomeWidgetEntry.empty
+}

--- a/Ushio/Home Screen Widget/HomeWidgetProvider.swift
+++ b/Ushio/Home Screen Widget/HomeWidgetProvider.swift
@@ -1,0 +1,127 @@
+//
+//  HomeWidgetProvider.swift
+//  Ushio
+//
+//  Created by シン・ジャスティン on 2026/02/20.
+//
+
+import SwiftData
+import SwiftUI
+import WidgetKit
+
+struct HomeWidgetEntry: TimelineEntry {
+    let date: Date
+    let clockInTime: Date?
+    let clockOutTime: Date?
+    let isOnBreak: Bool
+    let totalBreakTime: TimeInterval
+    let standardWorkingHours: TimeInterval
+
+    var isActive: Bool {
+        clockInTime != nil && clockOutTime == nil
+    }
+
+    var timeWorked: TimeInterval? {
+        guard let clockInTime else { return nil }
+        let endTime = clockOutTime ?? Date.now
+        return endTime.timeIntervalSince(clockInTime) - totalBreakTime
+    }
+
+    static var placeholder: HomeWidgetEntry {
+        HomeWidgetEntry(
+            date: .now,
+            clockInTime: Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: .now),
+            clockOutTime: nil,
+            isOnBreak: false,
+            totalBreakTime: 0,
+            standardWorkingHours: 8 * 3600
+        )
+    }
+
+    static var empty: HomeWidgetEntry {
+        HomeWidgetEntry(
+            date: .now,
+            clockInTime: nil,
+            clockOutTime: nil,
+            isOnBreak: false,
+            totalBreakTime: 0,
+            standardWorkingHours: 8 * 3600
+        )
+    }
+}
+
+struct HomeWidgetProvider: TimelineProvider {
+    func placeholder(in context: Context) -> HomeWidgetEntry {
+        .placeholder
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (HomeWidgetEntry) -> Void) {
+        if context.isPreview {
+            completion(.placeholder)
+        } else {
+            completion(fetchEntry())
+        }
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<HomeWidgetEntry>) -> Void) {
+        let entry = fetchEntry()
+
+        let refreshDate: Date
+        if entry.isActive {
+            // Refresh every 15 minutes while working
+            refreshDate = Calendar.current.date(byAdding: .minute, value: 15, to: .now) ?? .now
+        } else {
+            // Refresh every hour when idle
+            refreshDate = Calendar.current.date(byAdding: .hour, value: 1, to: .now) ?? .now
+        }
+
+        let timeline = Timeline(entries: [entry], policy: .after(refreshDate))
+        completion(timeline)
+    }
+
+    @MainActor
+    private func fetchEntry() -> HomeWidgetEntry {
+        let modelContext = SharedModelContainer.shared.container.mainContext
+        let standardWorkingHours = SettingsManager.shared.standardWorkingHours
+
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: .now)
+        let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? .now
+
+        let descriptor = FetchDescriptor<ClockEntry>(
+            predicate: #Predicate {
+                $0.clockInTime != nil &&
+                $0.clockInTime! >= startOfDay &&
+                $0.clockInTime! < endOfDay
+            },
+            sortBy: [SortDescriptor(\.clockInTime, order: .reverse)]
+        )
+
+        guard let entries = try? modelContext.fetch(descriptor),
+              let entry = entries.first else {
+            return HomeWidgetEntry(
+                date: .now,
+                clockInTime: nil,
+                clockOutTime: nil,
+                isOnBreak: false,
+                totalBreakTime: 0,
+                standardWorkingHours: standardWorkingHours
+            )
+        }
+
+        let totalBreakTime = (entry.breakTimes ?? []).reduce(into: 0.0) { result, breakTime in
+            if let end = breakTime.end {
+                result += end.timeIntervalSince(breakTime.start)
+            }
+        }
+
+        return HomeWidgetEntry(
+            date: .now,
+            clockInTime: entry.clockInTime,
+            clockOutTime: entry.clockOutTime,
+            isOnBreak: entry.isOnBreak,
+            totalBreakTime: totalBreakTime,
+            standardWorkingHours: standardWorkingHours
+        )
+    }
+}

--- a/Ushio/Home Screen Widget/HomeWidgetView.swift
+++ b/Ushio/Home Screen Widget/HomeWidgetView.swift
@@ -1,0 +1,255 @@
+//
+//  HomeWidgetView.swift
+//  Ushio
+//
+//  Created by シン・ジャスティン on 2026/02/20.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct HomeWidgetView: View {
+    @Environment(\.widgetFamily) var family
+    var entry: HomeWidgetEntry
+
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            smallWidget
+        case .systemMedium:
+            mediumWidget
+        default:
+            smallWidget
+        }
+    }
+
+    // MARK: - Small Widget
+
+    var smallWidget: some View {
+        VStack(alignment: .leading, spacing: 6.0) {
+            // Status indicator
+            HStack(spacing: 4.0) {
+                Image(systemName: statusIcon)
+                    .font(.caption2)
+                    .foregroundStyle(statusColor)
+                Text(statusText)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(statusColor)
+            }
+
+            Spacer()
+
+            if let clockInTime = entry.clockInTime {
+                // Clock in time
+                VStack(alignment: .leading, spacing: 2.0) {
+                    Text("TimeClock.Work.ClockIn")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(clockInTime, style: .time)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                }
+
+                // Time worked
+                if entry.clockOutTime != nil {
+                    if let timeWorked = entry.timeWorked {
+                        VStack(alignment: .leading, spacing: 2.0) {
+                            Text("Timesheet.TotalTimeWorked")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text(formatTimeInterval(timeWorked))
+                                .font(.headline)
+                                .fontWeight(.bold)
+                        }
+                    }
+                } else if entry.isActive {
+                    VStack(alignment: .leading, spacing: 2.0) {
+                        Text(entry.isOnBreak ? "TimeClock.Break.OnBreak" : "TimeClock.Work.Working")
+                            .font(.caption2)
+                            .foregroundStyle(entry.isOnBreak ? .orange : .secondary)
+                        Text(clockInTime, style: .relative)
+                            .font(.headline)
+                            .fontWeight(.bold)
+                            .foregroundStyle(entry.isOnBreak ? .orange : .primary)
+                    }
+                }
+            } else {
+                Text("Widget.NotClockedIn")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Medium Widget
+
+    var mediumWidget: some View {
+        HStack(spacing: 16.0) {
+            // Left side: times
+            VStack(alignment: .leading, spacing: 6.0) {
+                HStack(spacing: 4.0) {
+                    Image(systemName: statusIcon)
+                        .font(.caption2)
+                        .foregroundStyle(statusColor)
+                    Text(statusText)
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(statusColor)
+                }
+
+                Spacer()
+
+                if let clockInTime = entry.clockInTime {
+                    VStack(alignment: .leading, spacing: 2.0) {
+                        Text("TimeClock.Work.ClockIn")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text(clockInTime, style: .time)
+                            .font(.title3)
+                            .fontWeight(.bold)
+                    }
+
+                    if let clockOutTime = entry.clockOutTime {
+                        VStack(alignment: .leading, spacing: 2.0) {
+                            Text("TimeClock.Work.ClockOut")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text(clockOutTime, style: .time)
+                                .font(.headline)
+                                .fontWeight(.bold)
+                        }
+                    }
+                } else {
+                    Text("Widget.NotClockedIn")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Right side: work summary
+            if entry.clockInTime != nil {
+                VStack(alignment: .trailing, spacing: 6.0) {
+                    Spacer()
+
+                    if let clockOutTime = entry.clockOutTime,
+                       let clockInTime = entry.clockInTime {
+                        // Completed session
+                        VStack(alignment: .trailing, spacing: 2.0) {
+                            Text("Timesheet.TotalTimeWorked")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            let totalTime = clockOutTime.timeIntervalSince(clockInTime) - entry.totalBreakTime
+                            Text(formatTimeInterval(totalTime))
+                                .font(.title2)
+                                .fontWeight(.bold)
+                        }
+
+                        if entry.totalBreakTime > 0 {
+                            VStack(alignment: .trailing, spacing: 2.0) {
+                                Text("Shared.Break")
+                                    .font(.caption2)
+                                    .foregroundStyle(.orange)
+                                Text(formatTimeInterval(entry.totalBreakTime))
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .foregroundStyle(.orange)
+                            }
+                        }
+                    } else if entry.isActive, let clockInTime = entry.clockInTime {
+                        // Active session
+                        if entry.isOnBreak {
+                            VStack(alignment: .trailing, spacing: 2.0) {
+                                Text("TimeClock.Break.OnBreak")
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
+                                    .fontWeight(.semibold)
+                            }
+                        } else {
+                            let endWorkDate = clockInTime
+                                .addingTimeInterval(entry.totalBreakTime)
+                                .addingTimeInterval(entry.standardWorkingHours)
+
+                            VStack(alignment: .trailing, spacing: 2.0) {
+                                if Date.now >= endWorkDate {
+                                    HStack(spacing: 3.0) {
+                                        Image(systemName: "exclamationmark.triangle.fill")
+                                            .font(.caption2)
+                                        Text("Shared.Overtime")
+                                            .font(.caption2)
+                                            .fontWeight(.semibold)
+                                    }
+                                    .foregroundStyle(.red)
+                                } else {
+                                    HStack(spacing: 3.0) {
+                                        Image(systemName: "clock.badge.checkmark.fill")
+                                            .font(.caption2)
+                                        Text("Shared.Remaining")
+                                            .font(.caption2)
+                                            .fontWeight(.semibold)
+                                    }
+                                    .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+
+                        VStack(alignment: .trailing, spacing: 2.0) {
+                            Text(clockInTime, style: .relative)
+                                .font(.title2)
+                                .fontWeight(.bold)
+                                .foregroundStyle(entry.isOnBreak ? .orange : .primary)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    var statusIcon: String {
+        if entry.clockInTime == nil {
+            return "moon.zzz.fill"
+        } else if entry.clockOutTime != nil {
+            return "checkmark.circle.fill"
+        } else if entry.isOnBreak {
+            return "cup.and.heat.waves.fill"
+        } else {
+            return "clock.fill"
+        }
+    }
+
+    var statusColor: Color {
+        if entry.clockInTime == nil {
+            return .secondary
+        } else if entry.clockOutTime != nil {
+            return .green
+        } else if entry.isOnBreak {
+            return .orange
+        } else {
+            return .blue
+        }
+    }
+
+    var statusText: LocalizedStringKey {
+        if entry.clockInTime == nil {
+            return "Widget.Status.NotStarted"
+        } else if entry.clockOutTime != nil {
+            return "Widget.Status.Done"
+        } else if entry.isOnBreak {
+            return "TimeClock.Break.OnBreak"
+        } else {
+            return "TimeClock.Work.Working"
+        }
+    }
+
+    func formatTimeInterval(_ interval: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: max(0, interval)) ?? ""
+    }
+}

--- a/WorkingHour.xcodeproj/project.pbxproj
+++ b/WorkingHour.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -374,7 +374,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -530,7 +530,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour.Ushio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -558,7 +558,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour.Ushio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/WorkingHour/Localizable.xcstrings
+++ b/WorkingHour/Localizable.xcstrings
@@ -2029,6 +2029,91 @@
           }
         }
       }
+    },
+    "Widget.Description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View today's work session at a glance."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日の勤務状況をひと目で確認できます。"
+          }
+        }
+      }
+    },
+    "Widget.DisplayName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today's Work"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日の勤務"
+          }
+        }
+      }
+    },
+    "Widget.NotClockedIn" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not clocked in yet."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まだ出勤していません。"
+          }
+        }
+      }
+    },
+    "Widget.Status.Done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退勤済み"
+          }
+        }
+      }
+    },
+    "Widget.Status.NotStarted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Started"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未出勤"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/WorkingHour/Localizable.xcstrings
+++ b/WorkingHour/Localizable.xcstrings
@@ -686,6 +686,22 @@
         }
       }
     },
+    "Notification.Snooze" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snooze for 30 Minutes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30分後に再通知"
+          }
+        }
+      }
+    },
     "Projects.Active" : {
       "localizations" : {
         "en" : {

--- a/WorkingHour/Views/Shared/Entry Editor/EntryEditor.swift
+++ b/WorkingHour/Views/Shared/Entry Editor/EntryEditor.swift
@@ -240,7 +240,11 @@ struct EntryEditor: View {
     }
 
     private func saveEntry() {
-        // dataManager.updateClockEntry(entry)
+        if entry.clockOutTime == nil, let sessionData = entry.toWorkSessionData() {
+            Task {
+                await LiveActivities.updateActivity(with: sessionData)
+            }
+        }
     }
 
     private func formatTime(_ date: Date) -> String {


### PR DESCRIPTION
## Summary
This PR adds snooze functionality to clock-out reminders, allowing users to dismiss a notification and have it reappear 30 minutes later. The implementation includes notification action handling and Live Activity updates.

## Key Changes
- **NotificationManager refactoring**: Made the class conform to `UNUserNotificationCenterDelegate` to handle notification interactions
- **Notification actions**: Added a "Snooze for 30 Minutes" action to clock-out reminder notifications
- **Snooze logic**: Implemented `scheduleSnoozeReminder()` that reschedules the notification after 30 minutes (1800 seconds) when the snooze action is triggered
- **Category registration**: Added `registerCategories()` method to set up notification categories and actions during initialization
- **Localization**: Added English and Japanese translations for the snooze action button
- **Live Activities integration**: Uncommented and implemented the `saveEntry()` method to update Live Activities when a clock entry is created without a clock-out time

## Implementation Details
- The snooze action uses a `UNTimeIntervalNotificationTrigger` with a 30-minute interval for the rescheduled notification
- The delegate method is marked `nonisolated` to comply with the `@MainActor` constraint while handling async notification responses
- Snooze reminders use a separate identifier (`clockOutSnoozeReminder`) to distinguish them from regular clock-out reminders

https://claude.ai/code/session_01Bj67CuFSkqHaUphguWcWHg