### PR TITLE
Implement recurring clock-out reminders for weekdays

### DIFF
--- a/Shared/Managers/SettingsManager.swift
+++ b/Shared/Managers/SettingsManager.swift
@@ -127,6 +127,15 @@ final class SettingsManager {
         return components
     }
 
+    /// Convenience: returns `DateComponents` (hour + minute) for the stored clock-out time.
+    var clockOutReminderTimeComponents: DateComponents {
+        let totalSeconds = Int(clockOutReminderTime)
+        var components = DateComponents()
+        components.hour = totalSeconds / 3600
+        components.minute = (totalSeconds % 3600) / 60
+        return components
+    }
+
     // MARK: - Initialization
 
     private init() {

--- a/WorkingHour/Views/App.swift
+++ b/WorkingHour/Views/App.swift
@@ -54,11 +54,11 @@ struct WorkingHourApp: App {
         }
     }
 
-    /// Re-schedules clock-in reminders if they are enabled and were last
+    /// Re-schedules reminders if they are enabled and were last
     /// scheduled more than 7 days ago (or have never been scheduled).
     private func refreshClockInRemindersIfNeeded() {
         let settings = SettingsManager.shared
-        guard settings.clockInReminderEnabled else { return }
+        guard settings.clockInReminderEnabled || settings.clockOutReminderEnabled else { return }
 
         let needsRefresh: Bool
         if let lastScheduled = settings.notificationsLastScheduledDate {
@@ -73,10 +73,13 @@ struct WorkingHourApp: App {
 
         guard needsRefresh else { return }
 
-        let components = settings.clockInReminderTimeComponents
-
         Task {
-            await NotificationManager.shared.scheduleClockInReminders(at: components)
+            if settings.clockInReminderEnabled {
+                await NotificationManager.shared.scheduleClockInReminders(at: settings.clockInReminderTimeComponents)
+            }
+            if settings.clockOutReminderEnabled {
+                await NotificationManager.shared.scheduleClockOutReminder(at: settings.clockOutReminderTimeComponents)
+            }
             settings.notificationsLastScheduledDate = Date()
         }
     }

--- a/WorkingHour/Views/More/MoreView.swift
+++ b/WorkingHour/Views/More/MoreView.swift
@@ -255,7 +255,9 @@ struct MoreView: View {
                 await notificationManager.scheduleClockOutReminder(at: components)
             }
         } else {
-            notificationManager.cancelClockOutReminder()
+            Task {
+                await notificationManager.cancelClockOutReminder()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
This PR implements a recurring clock-out reminder system that schedules notifications for every weekday over a 30-day window, replacing the previous single repeating notification approach.

## Key Changes

- **NotificationManager.swift**
  - Modified `scheduleClockOutReminder()` to schedule individual notifications for each weekday in the next 30 days instead of a single repeating notification
  - Added logic to skip weekends and past trigger times
  - Changed notification identifiers to include the target date for better tracking
  - Updated `cancelClockOutReminder()` to be async and filter pending requests by identifier prefix to cancel all clock-out reminders

- **SettingsManager.swift**
  - Added `clockOutReminderTimeComponents` property to extract hour and minute from the stored clock-out reminder time, mirroring the existing `clockInReminderTimeComponents` implementation

- **App.swift**
  - Updated `refreshClockInRemindersIfNeeded()` to handle both clock-in and clock-out reminders
  - Modified the refresh logic to schedule both reminder types when enabled, rather than only clock-in reminders

- **MoreView.swift**
  - Wrapped `cancelClockOutReminder()` call in a Task to properly handle the async function

## Implementation Details

- Clock-out reminders are now scheduled for weekdays only (Monday-Friday), with weekends automatically skipped
- Each notification is scheduled individually with a unique identifier containing the target date
- Notifications scheduled for times already in the past are automatically skipped
- The system cancels all existing clock-out reminders before scheduling new ones to prevent duplicates
- The 30-day scheduling window is controlled by the `schedulingWindowDays` constant

https://claude.ai/code/session_017cBozY3hxHT38WBdF6PECY