### PR TITLE
Fix notification response handler to use completion handler

### DIFF
--- a/Shared/Managers/NotificationManager.swift
+++ b/Shared/Managers/NotificationManager.swift
@@ -208,10 +208,16 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse
-    ) async {
-        guard response.actionIdentifier == Action.snooze else { return }
-        await scheduleSnoozeReminder()
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let actionIdentifier = response.actionIdentifier
+        Task { @MainActor in
+            if actionIdentifier == Action.snooze {
+                await self.scheduleSnoozeReminder()
+            }
+            completionHandler()
+        }
     }
 
     private func scheduleSnoozeReminder() async {

--- a/WorkingHour.xcodeproj/project.pbxproj
+++ b/WorkingHour.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -374,7 +374,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -530,7 +530,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour.Ushio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -558,7 +558,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour.Ushio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Summary
Updated the notification response handler to use the completion handler-based delegate method instead of the async/await variant, ensuring proper notification handling on all iOS versions.

## Key Changes
- Modified `userNotificationCenter(_:didReceive:withCompletionHandler:)` to use the completion handler pattern instead of async/await
- Wrapped the snooze action logic in a `Task` with `@MainActor` annotation to maintain thread safety
- Ensured `completionHandler()` is called after processing the notification response
- Bumped marketing version from 1.0.2 to 1.0.3 across all targets

## Implementation Details
The notification response handler now:
1. Extracts the action identifier from the response
2. Dispatches work to the main actor using `Task { @MainActor in ... }`
3. Checks if the action is a snooze action and schedules a reminder if needed
4. Calls the completion handler to signal completion to the system

This approach ensures compatibility and proper lifecycle management of notification handling across different iOS versions.

https://claude.ai/code/session_01F8iWjYFUdQFupYdj7giDss