### PR TITLE
Refactor live activity stale date calculation logic

### DIFF
--- a/Shared/Managers/LiveActivities.swift
+++ b/Shared/Managers/LiveActivities.swift
@@ -9,6 +9,16 @@ import ActivityKit
 import Foundation
 
 class LiveActivities {
+    private static func staleDateForClockIn(_ clockInTime: Date) -> Date {
+        let calendar = Calendar.current
+        let hour = calendar.component(.hour, from: clockInTime)
+        let targetDate = hour >= 21
+            ? calendar.date(byAdding: .day, value: 1, to: clockInTime)!
+            : clockInTime
+        return calendar.startOfDay(for: calendar.date(byAdding: .day, value: 1, to: targetDate)!)
+    }
+
+
     public static func hasActivity(for entryId: String) -> Bool {
         let activities = Activity<UshioAttributes>.activities
         return activities.contains(where: { $0.attributes.entryId == entryId })
@@ -44,7 +54,7 @@ class LiveActivities {
             totalBreakTime: data.totalBreakTime,
             standardWorkingHours: data.standardWorkingHours
         )
-        let staleDate = data.clockInTime.addingTimeInterval(data.standardWorkingHours + 14400)
+        let staleDate = staleDateForClockIn(data.clockInTime)
         let content = ActivityContent(state: contentState, staleDate: staleDate)
 
         do {
@@ -64,7 +74,7 @@ class LiveActivities {
             totalBreakTime: data.totalBreakTime,
             standardWorkingHours: data.standardWorkingHours
         )
-        let staleDate = data.clockInTime.addingTimeInterval(data.standardWorkingHours + 14400)
+        let staleDate = staleDateForClockIn(data.clockInTime)
         let content = ActivityContent(state: contentState, staleDate: staleDate)
 
         let activities = Activity<UshioAttributes>.activities


### PR DESCRIPTION
## Summary
Extracted the stale date calculation logic for live activities into a dedicated private method to improve code maintainability and centralize the business logic.

## Key Changes
- Added `staleDateForClockIn(_:)` private static method that calculates the stale date based on clock-in time
  - For clock-ins at 21:00 or later, the stale date is set to the start of the day after tomorrow
  - For earlier clock-ins, the stale date is set to the start of tomorrow
- Replaced two instances of inline stale date calculation (`data.clockInTime.addingTimeInterval(data.standardWorkingHours + 14400)`) with calls to the new method in both `requestLiveActivity` and `updateLiveActivity` methods

## Implementation Details
The new calculation method uses `Calendar` APIs to:
1. Extract the hour component from the clock-in time
2. Determine the target date based on whether the clock-in occurred at or after 21:00
3. Return the start of the day following the target date

This replaces the previous time interval-based approach with a calendar-based approach that's more explicit about the business logic intent.

https://claude.ai/code/session_01WjRsaHhezryP6PxX52C2jB