### PR TITLE
Fix break time range validation and clock-out reminder scheduling

### DIFF
--- a/WorkingHour.xcodeproj/project.pbxproj
+++ b/WorkingHour.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -374,7 +374,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -530,7 +530,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour.Ushio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -558,7 +558,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour.Ushio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/WorkingHour/Views/More/NotificationsSettingsView.swift
+++ b/WorkingHour/Views/More/NotificationsSettingsView.swift
@@ -99,6 +99,18 @@ struct NotificationsSettingsView: View {
                 await notificationManager.cancelClockInReminders()
             }
         }
+
+        if clockOutReminderEnabled {
+            let components = Calendar.current.dateComponents([.hour, .minute], from: clockOutReminderTime)
+            Task {
+                await notificationManager.scheduleClockOutReminder(at: components)
+                settingsManager.notificationsLastScheduledDate = Date()
+            }
+        } else {
+            Task {
+                await notificationManager.cancelClockOutReminder()
+            }
+        }
     }
 
     private func secondsSinceMidnight(from date: Date) -> Double {

--- a/WorkingHour/Views/Shared/Entry Editor/EntryEditor.swift
+++ b/WorkingHour/Views/Shared/Entry Editor/EntryEditor.swift
@@ -31,6 +31,14 @@ struct EntryEditor: View {
         self.hasClockOutTime = entry.clockOutTime != nil
     }
 
+    var safeBreakTimeRange: ClosedRange<Date> {
+        if newClockInTime <= newClockOutTime {
+            return newClockInTime...newClockOutTime
+        } else {
+            return newClockOutTime...newClockInTime
+        }
+    }
+
     var sortedBreakTimes: [Break] {
         (entry.breakTimes ?? []).sorted { $0.start < $1.start }
     }
@@ -56,7 +64,7 @@ struct EntryEditor: View {
                     }
                 }
             }
-        ), in: newClockInTime...newClockOutTime)
+        ), in: safeBreakTimeRange)
 
         if (entry.breakTimes ?? [])[index].end != nil {
             TimelineRow(.breakEnd, date: Binding(
@@ -66,7 +74,7 @@ struct EntryEditor: View {
                         (entry.breakTimes ?? [])[index].end = newEnd
                     }
                 }
-            ), in: newClockInTime...newClockOutTime)
+            ), in: safeBreakTimeRange)
         } else {
             TimelineRow(.breakTime, date: .constant(.distantPast))
         }
@@ -77,13 +85,13 @@ struct EntryEditor: View {
     var body: some View {
         NavigationStack {
             List {
-                TimelineRow(.start, date: $newClockInTime)
+                TimelineRow(.start, date: $newClockInTime, in: hasClockOutTime ? .distantPast...newClockOutTime : nil)
                 if !sortedBreakTimes.isEmpty {
                     TimelineRow(.neutral, date: .constant(.distantPast))
                 }
                 breakTimesView
                 if hasClockOutTime {
-                    TimelineRow(.end, date: $newClockOutTime)
+                    TimelineRow(.end, date: $newClockOutTime, in: newClockInTime...Date.distantFuture)
                 }
 
                 // Break Management Section
@@ -197,13 +205,13 @@ struct EntryEditor: View {
                             DatePicker(
                                 "EntryEditor.Break.Start",
                                 selection: $newBreakStart,
-                                in: newClockInTime...newClockOutTime,
+                                in: safeBreakTimeRange,
                                 displayedComponents: [.date, .hourAndMinute]
                             )
                             DatePicker(
                                 "EntryEditor.Break.End",
                                 selection: $newBreakEnd,
-                                in: newClockInTime...newClockOutTime,
+                                in: safeBreakTimeRange,
                                 displayedComponents: [.date, .hourAndMinute]
                             )
                         } footer: {


### PR DESCRIPTION
## Summary
This PR fixes issues with break time range validation when clock times are entered out of order, and implements clock-out reminder scheduling in the notifications settings.

## Key Changes
- **EntryEditor.swift**: Added `safeBreakTimeRange` computed property that handles cases where clock-in time is after clock-out time by swapping the range bounds. This ensures break time pickers always have a valid range regardless of clock time order.
- **EntryEditor.swift**: Updated all break time DatePicker constraints to use `safeBreakTimeRange` instead of the potentially invalid `newClockInTime...newClockOutTime` range.
- **EntryEditor.swift**: Added range constraints to clock-in and clock-out TimelineRow components to prevent invalid time selections.
- **NotificationsSettingsView.swift**: Implemented clock-out reminder scheduling logic that mirrors the existing clock-in reminder functionality, including scheduling and cancellation based on the `clockOutReminderEnabled` toggle.
- **Version bump**: Updated marketing version from 1.0.3 to 1.0.4 across all build configurations.

## Notable Implementation Details
- The `safeBreakTimeRange` property ensures break times can be edited even when clock times are entered in reverse order, improving UX for edge cases.
- Clock-out reminder scheduling follows the same pattern as clock-in reminders, extracting hour/minute components and updating the last scheduled date.

https://claude.ai/code/session_01UJi99oN1hFXst8hnnT7CfM