### PR TITLE
Refresh live activities on app launch and show stale warning

### DIFF
--- a/Shared/Managers/LiveActivities.swift
+++ b/Shared/Managers/LiveActivities.swift
@@ -9,13 +9,18 @@ import ActivityKit
 import Foundation
 
 class LiveActivities {
-    private static func staleDateForClockIn(_ clockInTime: Date) -> Date {
-        let calendar = Calendar.current
-        let hour = calendar.component(.hour, from: clockInTime)
-        let targetDate = hour >= 21
-            ? calendar.date(byAdding: .day, value: 1, to: clockInTime)!
-            : clockInTime
-        return calendar.startOfDay(for: calendar.date(byAdding: .day, value: 1, to: targetDate)!)
+    /// Tracks whether the live activities have already been refreshed for the
+    /// current app launch. Used by `refreshOnLaunch` to ensure the full
+    /// end-and-restart cycle only runs once per process lifetime.
+    private static var hasRefreshedOnLaunch = false
+
+    /// ActivityKit caps the stale date at 8 hours from now. We use a value
+    /// slightly below that cap so the activity reliably transitions to the
+    /// stale state, prompting the user to open the app to refresh it.
+    private static let staleDateInterval: TimeInterval = 8 * 60 * 60 - 60
+
+    private static func nextStaleDate() -> Date {
+        return Date().addingTimeInterval(staleDateInterval)
     }
 
 
@@ -39,6 +44,33 @@ class LiveActivities {
         await startActivity(with: data)
     }
 
+    /// Ends every currently tracked live activity. Called when the app
+    /// launches so we can start fresh activities with a reset stale date.
+    public static func endAllActivities(immediately: Bool = true) async {
+        let activities = Activity<UshioAttributes>.activities
+        log("LiveActivityManager: Ending all \(activities.count) activities")
+        for activity in activities {
+            await activity.end(nil, dismissalPolicy: immediately ? .immediate : .default)
+        }
+    }
+
+    /// On the first call per app launch, ends every existing live activity
+    /// and starts a fresh one for the current active session (if any). On
+    /// subsequent calls within the same launch, just ensures the activity
+    /// exists without tearing it down (avoids flicker on scene transitions).
+    public static func refreshOnLaunch(with data: WorkSessionData?) async {
+        if !hasRefreshedOnLaunch {
+            hasRefreshedOnLaunch = true
+            log("LiveActivityManager: Refreshing live activities on launch")
+            await endAllActivities(immediately: true)
+            if let data, data.clockOutTime == nil {
+                await startActivity(with: data)
+            }
+        } else if let data {
+            await ensureActivity(with: data)
+        }
+    }
+
     public static func startActivity(with data: WorkSessionData) async {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else {
             log("LiveActivityManager: Activities are disabled for this app on this device")
@@ -54,8 +86,7 @@ class LiveActivities {
             totalBreakTime: data.totalBreakTime,
             standardWorkingHours: data.standardWorkingHours
         )
-        let staleDate = staleDateForClockIn(data.clockInTime)
-        let content = ActivityContent(state: contentState, staleDate: staleDate)
+        let content = ActivityContent(state: contentState, staleDate: nextStaleDate())
 
         do {
             let activity = try Activity<UshioAttributes>.request(attributes: attributes, content: content)
@@ -74,8 +105,7 @@ class LiveActivities {
             totalBreakTime: data.totalBreakTime,
             standardWorkingHours: data.standardWorkingHours
         )
-        let staleDate = staleDateForClockIn(data.clockInTime)
-        let content = ActivityContent(state: contentState, staleDate: staleDate)
+        let content = ActivityContent(state: contentState, staleDate: nextStaleDate())
 
         let activities = Activity<UshioAttributes>.activities
         log("LiveActivityManager: Looking for activity with entryId: \(data.entryId) in \(activities.count) activities")

--- a/Shared/Managers/LiveActivities.swift
+++ b/Shared/Managers/LiveActivities.swift
@@ -14,13 +14,13 @@ class LiveActivities {
     /// end-and-restart cycle only runs once per process lifetime.
     private static var hasRefreshedOnLaunch = false
 
-    /// ActivityKit caps the stale date at 8 hours from now. We use a value
-    /// slightly below that cap so the activity reliably transitions to the
-    /// stale state, prompting the user to open the app to refresh it.
-    private static let staleDateInterval: TimeInterval = 8 * 60 * 60 - 60
+    /// Maximum stale interval allowed by ActivityKit (8 hours from now).
+    /// After this point the activity transitions to the stale state,
+    /// prompting the user to open the app to refresh it.
+    private static let maxStaleInterval: TimeInterval = 8 * 60 * 60
 
     private static func nextStaleDate() -> Date {
-        return Date().addingTimeInterval(staleDateInterval)
+        return Date().addingTimeInterval(maxStaleInterval)
     }
 
 

--- a/Ushio/Live Activity/LiveActivityView.swift
+++ b/Ushio/Live Activity/LiveActivityView.swift
@@ -123,33 +123,31 @@ struct LiveActivityView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            // Stale warning: prompt the user to reopen the app to refresh
-            // the live activity. ActivityKit caps the stale date at 8 hours,
-            // so when it elapses we ask the user to refresh or end the
-            // session from the app.
-            if context.isStale && context.state.clockOutTime == nil {
-                HStack(spacing: 6) {
-                    Image(systemName: "exclamationmark.arrow.circlepath")
-                        .font(.caption)
-                    Text("LiveActivity.Stale.Message")
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .multilineTextAlignment(.leading)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .foregroundStyle(.orange)
-                .padding(.vertical, 6)
-                .padding(.horizontal, 10)
-                .frame(maxWidth: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.orange.opacity(0.15))
-                )
-            }
-
-            // Action buttons (only show when not clocked out)
+            // Action buttons (only show when not clocked out).
+            // When the activity has gone stale (ActivityKit caps the stale
+            // date at 8 hours) replace the buttons with a prompt telling
+            // the user to open the app to refresh or end their session.
             if context.state.clockOutTime == nil {
-                HStack(spacing: 8) {
+                if context.isStale {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.arrow.circlepath")
+                            .font(.caption)
+                        Text("LiveActivity.Stale.Message")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .foregroundStyle(.orange)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 10)
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.orange.opacity(0.15))
+                    )
+                } else {
+                    HStack(spacing: 8) {
                     if context.state.isOnBreak {
                         Button(intent: EndBreakIntent(entryId: context.attributes.entryId)) {
                             Label {
@@ -189,6 +187,7 @@ struct LiveActivityView: View {
                         }
                         .tint(.red)
                         .buttonStyle(.borderedProminent)
+                    }
                     }
                 }
             }

--- a/Ushio/Live Activity/LiveActivityView.swift
+++ b/Ushio/Live Activity/LiveActivityView.swift
@@ -123,29 +123,11 @@ struct LiveActivityView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            // Action buttons (only show when not clocked out).
-            // When the activity has gone stale (ActivityKit caps the stale
-            // date at 8 hours) replace the buttons with a prompt telling
-            // the user to open the app to refresh or end their session.
+            // Action buttons (only show when not clocked out). When the
+            // activity has gone stale, StaleWarningView takes their place.
             if context.state.clockOutTime == nil {
                 if context.isStale {
-                    HStack(spacing: 6) {
-                        Image(systemName: "exclamationmark.arrow.circlepath")
-                            .font(.caption)
-                        Text("LiveActivity.Stale.Message")
-                            .font(.caption2)
-                            .fontWeight(.semibold)
-                            .multilineTextAlignment(.leading)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .foregroundStyle(.orange)
-                    .padding(.vertical, 6)
-                    .padding(.horizontal, 10)
-                    .frame(maxWidth: .infinity)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color.orange.opacity(0.15))
-                    )
+                    StaleWarningView()
                 } else {
                     HStack(spacing: 8) {
                     if context.state.isOnBreak {

--- a/Ushio/Live Activity/LiveActivityView.swift
+++ b/Ushio/Live Activity/LiveActivityView.swift
@@ -123,6 +123,30 @@ struct LiveActivityView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
+            // Stale warning: prompt the user to reopen the app to refresh
+            // the live activity. ActivityKit caps the stale date at 8 hours,
+            // so when it elapses we ask the user to refresh or end the
+            // session from the app.
+            if context.isStale && context.state.clockOutTime == nil {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.arrow.circlepath")
+                        .font(.caption)
+                    Text("LiveActivity.Stale.Message")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .foregroundStyle(.orange)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.orange.opacity(0.15))
+                )
+            }
+
             // Action buttons (only show when not clocked out)
             if context.state.clockOutTime == nil {
                 HStack(spacing: 8) {

--- a/Ushio/Live Activity/StaleWarningView.swift
+++ b/Ushio/Live Activity/StaleWarningView.swift
@@ -1,0 +1,34 @@
+//
+//  StaleWarningView.swift
+//  Ushio
+//
+//  Created by シン・ジャスティン on 2026/04/10.
+//
+
+import SwiftUI
+
+/// Prompt shown in place of the live activity action buttons when the
+/// activity has gone stale. ActivityKit caps the stale date at 8 hours,
+/// so once it elapses we ask the user to open the app to refresh it or
+/// end their session from the main UI.
+struct StaleWarningView: View {
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.arrow.circlepath")
+                .font(.caption)
+            Text("LiveActivity.Stale.Message")
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .foregroundStyle(.orange)
+        .padding(.vertical, 6)
+        .padding(.horizontal, 10)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.orange.opacity(0.15))
+        )
+    }
+}

--- a/Ushio/Live Activity/Widget.swift
+++ b/Ushio/Live Activity/Widget.swift
@@ -58,28 +58,11 @@ struct UshioLiveActivity: Widget {
                     .padding(.top, 2.0)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    // When the activity has gone stale, replace the action
-                    // buttons with a prompt telling the user to open the
-                    // app to refresh or end their session.
+                    // When the activity has gone stale, StaleWarningView
+                    // takes the place of the action buttons.
                     if context.isStale && context.state.clockOutTime == nil {
-                        HStack(spacing: 6) {
-                            Image(systemName: "exclamationmark.arrow.circlepath")
-                                .font(.caption)
-                            Text("LiveActivity.Stale.Message")
-                                .font(.caption2)
-                                .fontWeight(.semibold)
-                                .multilineTextAlignment(.leading)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .foregroundStyle(.orange)
-                        .padding(.vertical, 6)
-                        .padding(.horizontal, 10)
-                        .frame(maxWidth: .infinity)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(Color.orange.opacity(0.15))
-                        )
-                        .padding(.top, 8)
+                        StaleWarningView()
+                            .padding(.top, 8)
                     } else {
                         HStack(spacing: 8) {
                             if context.state.isOnBreak {

--- a/Ushio/Live Activity/Widget.swift
+++ b/Ushio/Live Activity/Widget.swift
@@ -58,26 +58,29 @@ struct UshioLiveActivity: Widget {
                     .padding(.top, 2.0)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    VStack(spacing: 8) {
-                        if context.isStale && context.state.clockOutTime == nil {
-                            HStack(spacing: 6) {
-                                Image(systemName: "exclamationmark.arrow.circlepath")
-                                    .font(.caption)
-                                Text("LiveActivity.Stale.Message")
-                                    .font(.caption2)
-                                    .fontWeight(.semibold)
-                                    .multilineTextAlignment(.leading)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                            }
-                            .foregroundStyle(.orange)
-                            .padding(.vertical, 6)
-                            .padding(.horizontal, 10)
-                            .frame(maxWidth: .infinity)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(Color.orange.opacity(0.15))
-                            )
+                    // When the activity has gone stale, replace the action
+                    // buttons with a prompt telling the user to open the
+                    // app to refresh or end their session.
+                    if context.isStale && context.state.clockOutTime == nil {
+                        HStack(spacing: 6) {
+                            Image(systemName: "exclamationmark.arrow.circlepath")
+                                .font(.caption)
+                            Text("LiveActivity.Stale.Message")
+                                .font(.caption2)
+                                .fontWeight(.semibold)
+                                .multilineTextAlignment(.leading)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                         }
+                        .foregroundStyle(.orange)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 10)
+                        .frame(maxWidth: .infinity)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color.orange.opacity(0.15))
+                        )
+                        .padding(.top, 8)
+                    } else {
                         HStack(spacing: 8) {
                             if context.state.isOnBreak {
                                 Button(intent: EndBreakIntent(entryId: context.attributes.entryId)) {
@@ -123,8 +126,8 @@ struct UshioLiveActivity: Widget {
                                 .buttonStyle(.bordered)
                             }
                         }
+                        .padding(.top, 8)
                     }
-                    .padding(.top, 8)
                 }
             } compactLeading: {
                 if context.state.isOnBreak {

--- a/Ushio/Live Activity/Widget.swift
+++ b/Ushio/Live Activity/Widget.swift
@@ -58,49 +58,70 @@ struct UshioLiveActivity: Widget {
                     .padding(.top, 2.0)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    HStack(spacing: 8) {
-                        if context.state.isOnBreak {
-                            Button(intent: EndBreakIntent(entryId: context.attributes.entryId)) {
-                                Label {
-                                    Text("TimeClock.Break.End")
-                                } icon: {
-                                    Image(systemName: "arrowshape.turn.up.backward.badge.clock.fill")
-                                }
-                                .font(.body)
-                                .fontWeight(.semibold)
-                                .padding(.vertical, 4)
-                                .frame(maxWidth: .infinity)
+                    VStack(spacing: 8) {
+                        if context.isStale && context.state.clockOutTime == nil {
+                            HStack(spacing: 6) {
+                                Image(systemName: "exclamationmark.arrow.circlepath")
+                                    .font(.caption)
+                                Text("LiveActivity.Stale.Message")
+                                    .font(.caption2)
+                                    .fontWeight(.semibold)
+                                    .multilineTextAlignment(.leading)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                             }
-                            .tint(.red)
-                            .buttonStyle(.bordered)
-                        } else {
-                            Button(intent: StartBreakIntent(entryId: context.attributes.entryId)) {
-                                Label {
-                                    Text("Shared.Break")
-                                } icon: {
-                                    Image(systemName: "cup.and.heat.waves.fill")
+                            .foregroundStyle(.orange)
+                            .padding(.vertical, 6)
+                            .padding(.horizontal, 10)
+                            .frame(maxWidth: .infinity)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color.orange.opacity(0.15))
+                            )
+                        }
+                        HStack(spacing: 8) {
+                            if context.state.isOnBreak {
+                                Button(intent: EndBreakIntent(entryId: context.attributes.entryId)) {
+                                    Label {
+                                        Text("TimeClock.Break.End")
+                                    } icon: {
+                                        Image(systemName: "arrowshape.turn.up.backward.badge.clock.fill")
+                                    }
+                                    .font(.body)
+                                    .fontWeight(.semibold)
+                                    .padding(.vertical, 4)
+                                    .frame(maxWidth: .infinity)
                                 }
-                                .font(.body)
-                                .fontWeight(.semibold)
-                                .padding(.vertical, 4)
-                                .frame(maxWidth: .infinity)
-                            }
-                            .tint(.orange)
-                            .buttonStyle(.bordered)
+                                .tint(.red)
+                                .buttonStyle(.bordered)
+                            } else {
+                                Button(intent: StartBreakIntent(entryId: context.attributes.entryId)) {
+                                    Label {
+                                        Text("Shared.Break")
+                                    } icon: {
+                                        Image(systemName: "cup.and.heat.waves.fill")
+                                    }
+                                    .font(.body)
+                                    .fontWeight(.semibold)
+                                    .padding(.vertical, 4)
+                                    .frame(maxWidth: .infinity)
+                                }
+                                .tint(.orange)
+                                .buttonStyle(.bordered)
 
-                            Button(intent: ClockOutIntent(entryId: context.attributes.entryId)) {
-                                Label {
-                                    Text("TimeClock.Work.ClockOut")
-                                } icon: {
-                                    Image(systemName: "stop.fill")
+                                Button(intent: ClockOutIntent(entryId: context.attributes.entryId)) {
+                                    Label {
+                                        Text("TimeClock.Work.ClockOut")
+                                    } icon: {
+                                        Image(systemName: "stop.fill")
+                                    }
+                                    .font(.body)
+                                    .fontWeight(.semibold)
+                                    .padding(.vertical, 4)
+                                    .frame(maxWidth: .infinity)
                                 }
-                                .font(.body)
-                                .fontWeight(.semibold)
-                                .padding(.vertical, 4)
-                                .frame(maxWidth: .infinity)
+                                .tint(.red)
+                                .buttonStyle(.bordered)
                             }
-                            .tint(.red)
-                            .buttonStyle(.bordered)
                         }
                     }
                     .padding(.top, 8)

--- a/WorkingHour/Localizable.xcstrings
+++ b/WorkingHour/Localizable.xcstrings
@@ -497,6 +497,23 @@
         }
       }
     },
+    "LiveActivity.Stale.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open the app to refresh or end your session"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリを開いて更新するか、退勤してください"
+          }
+        }
+      }
+    },
     "More.Projects" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/WorkingHour/Views/App.swift
+++ b/WorkingHour/Views/App.swift
@@ -47,11 +47,15 @@ struct WorkingHourApp: App {
             sortBy: [SortDescriptor(\.clockInTime, order: .reverse)]
         )
 
-        if let activeEntry = try? context.fetch(descriptor).first,
-           let sessionData = activeEntry.toWorkSessionData() {
-            Task {
-                await LiveActivities.ensureActivity(with: sessionData)
-            }
+        let activeEntry = try? context.fetch(descriptor).first
+        let sessionData = activeEntry?.toWorkSessionData()
+
+        // On first launch this closes every existing live activity and
+        // starts a fresh one (resetting the 8-hour stale date). On
+        // subsequent foreground transitions within the same process it
+        // just ensures an activity exists.
+        Task {
+            await LiveActivities.refreshOnLaunch(with: sessionData)
         }
     }
 


### PR DESCRIPTION
End all live activities when the app starts and reopen a fresh one
for any active session so the 8-hour ActivityKit stale date resets
each time the user opens the app. The stale date is now anchored to
the current time (capped just below the 8-hour system limit) rather
than to the clock-in time so it behaves predictably.

Also show an in-activity banner when the live activity goes stale,
prompting the user to open the app to refresh or end their session.

https://claude.ai/code/session_016wM2iNQronUGB1bRB9jUhY