### PR TITLE
Fix and harden geofence-based clock-in/out and breaks

### DIFF
--- a/Shared/Data Models/ClockEntry.swift
+++ b/Shared/Data Models/ClockEntry.swift
@@ -153,7 +153,7 @@ final class ClockEntry: Identifiable {
             clockInTime: clockInTime,
             clockOutTime: self.clockOutTime,
             isOnBreak: self.isOnBreak,
-            breakStartTime: self.isOnBreak ? (self.breakTimes ?? []).last?.start : nil,
+            breakStartTime: self.isOnBreak ? (self.breakTimes ?? []).first(where: { $0.end == nil })?.start : nil,
             totalBreakTime: totalBreakTime,
             standardWorkingHours: standardWorkingHours,
             defaultBreakDuration: defaultBreakDuration

--- a/Shared/Managers/GeofencingManager.swift
+++ b/Shared/Managers/GeofencingManager.swift
@@ -166,14 +166,6 @@ final class GeofencingManager: NSObject {
 
             let newEntry = ClockEntry(.now)
 
-            if settings.defaultBreakDuration > 0 {
-                let breakStart = Date.now
-                let breakEnd = breakStart.addingTimeInterval(settings.defaultBreakDuration)
-                let newBreak = Break(start: breakStart, end: breakEnd)
-                newBreak.clockEntry = newEntry
-                modelContext.insert(newBreak)
-            }
-
             modelContext.insert(newEntry)
             try modelContext.save()
             DataManager.shared.loadAll()

--- a/Shared/Managers/GeofencingManager.swift
+++ b/Shared/Managers/GeofencingManager.swift
@@ -21,11 +21,25 @@ final class GeofencingManager: NSObject {
     var authorizationStatus: CLAuthorizationStatus = .notDetermined
     var isMonitoring: Bool = false
 
-    /// Region exits awaiting confirmation via `requestState`.
-    private var pendingExitConfirmations: Set<String> = []
+    /// A confirmed boundary crossing, used to debounce flapping at the edge.
+    private enum RegionTransition { case entered, exited }
 
-    /// Exit events received before this date are ignored.
-    private var ignoreExitEventsUntil: Date = .distantPast
+    /// Region boundary crossings awaiting confirmation via `requestState`,
+    /// keyed by region identifier with the direction that triggered them.
+    private var pendingConfirmations: [String: RegionTransition] = [:]
+
+    /// Entry/exit events received before this date are ignored, to let regions
+    /// settle after (re-)registration.
+    private var ignoreEventsUntil: Date = .distantPast
+
+    /// The last transition we acted on, and when — used to drop duplicate or
+    /// rapidly-flapping events while lingering at the boundary.
+    private var lastActedTransition: RegionTransition?
+    private var lastActedTransitionAt: Date = .distantPast
+
+    /// Minimum spacing between two *same-direction* transitions. Opposite
+    /// directions (a genuine state change) are always allowed through.
+    private let transitionCooldown: TimeInterval = 60
 
     private override init() {
         super.init()
@@ -81,8 +95,9 @@ final class GeofencingManager: NSObject {
         // Stop all existing monitoring first
         stopMonitoringAllRegions()
 
-        // Ignore exits briefly while regions settle after re-registration.
-        ignoreExitEventsUntil = Date().addingTimeInterval(15)
+        // Ignore entries and exits briefly while regions settle after
+        // re-registration, which otherwise re-deliver spurious crossings.
+        ignoreEventsUntil = Date().addingTimeInterval(15)
 
         do {
             let descriptor = FetchDescriptor<Workplace>(
@@ -210,11 +225,12 @@ final class GeofencingManager: NSObject {
 
             guard settings.autoClockOutEnabled else { return }
 
-            // End any active break first
+            // End any active break first. Find the open break explicitly —
+            // `breakTimes` is an unordered SwiftData relationship, so `.last`
+            // is not reliably the ongoing one.
             if activeEntry.isOnBreak,
-               let lastBreak = (activeEntry.breakTimes ?? []).last,
-               lastBreak.end == nil {
-                lastBreak.end = .now
+               let openBreak = (activeEntry.breakTimes ?? []).first(where: { $0.end == nil }) {
+                openBreak.end = .now
                 activeEntry.isOnBreak = false
             }
 
@@ -292,14 +308,15 @@ final class GeofencingManager: NSObject {
         )
 
         do {
+            // `breakTimes` is unordered, so locate the open break explicitly
+            // rather than relying on `.last`.
             guard let activeEntry = try modelContext.fetch(descriptor).first,
                   activeEntry.isOnBreak,
-                  let lastBreak = (activeEntry.breakTimes ?? []).last,
-                  lastBreak.end == nil else {
+                  let openBreak = (activeEntry.breakTimes ?? []).first(where: { $0.end == nil }) else {
                 return false
             }
 
-            lastBreak.end = .now
+            openBreak.end = .now
             activeEntry.isOnBreak = false
             try modelContext.save()
             DataManager.shared.loadAll()
@@ -341,27 +358,14 @@ extension GeofencingManager: CLLocationManagerDelegate {
     nonisolated func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
         guard region is CLCircularRegion else { return }
         Task { @MainActor in
-            log("GeofencingManager: Entered region \(region.identifier)", prefix: "MIKA")
-            self.handleRegionEntry()
+            self.queueConfirmation(.entered, for: region, with: manager)
         }
     }
 
     nonisolated func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
         guard region is CLCircularRegion else { return }
         Task { @MainActor in
-            log("GeofencingManager: Exited region \(region.identifier)", prefix: "MIKA")
-
-            if Date() < self.ignoreExitEventsUntil {
-                log(
-                    "GeofencingManager: Ignoring exit for \(region.identifier) during monitoring settling window",
-                    prefix: "MIKA"
-                )
-                return
-            }
-
-            // Confirm the device is genuinely outside before clocking out.
-            self.pendingExitConfirmations.insert(region.identifier)
-            manager.requestState(for: region)
+            self.queueConfirmation(.exited, for: region, with: manager)
         }
     }
 
@@ -372,25 +376,66 @@ extension GeofencingManager: CLLocationManagerDelegate {
     ) {
         guard region is CLCircularRegion else { return }
         Task { @MainActor in
-            // Only act on states we explicitly requested to confirm an exit.
-            guard self.pendingExitConfirmations.remove(region.identifier) != nil else { return }
+            // Only act on states we explicitly requested to confirm a crossing.
+            guard let transition = self.pendingConfirmations.removeValue(forKey: region.identifier) else { return }
 
-            // Trust the exit unless the device is definitively back inside.
-            // Dropping `.unknown` (no fresh fix yet, common in the background)
-            // would silently miss legitimate exits.
-            if state == .inside {
-                log(
-                    "GeofencingManager: Ignoring exit for \(region.identifier); device is still inside",
-                    prefix: "MIKA"
-                )
-            } else {
-                log(
-                    "GeofencingManager: Confirmed exit for \(region.identifier) (state=\(state.rawValue))",
-                    prefix: "MIKA"
-                )
-                self.handleRegionExit()
+            // Use the confirmed state to veto obvious GPS jitter, but trust the
+            // original event (including `.unknown`, which is common in the
+            // background) so genuine crossings are never silently dropped.
+            switch transition {
+            case .entered:
+                guard state != .outside else {
+                    log("GeofencingManager: Ignoring entry for \(region.identifier); device is outside", prefix: "MIKA")
+                    return
+                }
+                self.act(on: .entered, region: region.identifier, state: state) { self.handleRegionEntry() }
+            case .exited:
+                guard state != .inside else {
+                    log("GeofencingManager: Ignoring exit for \(region.identifier); device is still inside", prefix: "MIKA")
+                    return
+                }
+                self.act(on: .exited, region: region.identifier, state: state) { self.handleRegionExit() }
             }
         }
+    }
+
+    /// Records a boundary crossing and asks Core Location to confirm the
+    /// device's current state before acting, unless we're still settling.
+    private func queueConfirmation(
+        _ transition: RegionTransition,
+        for region: CLRegion,
+        with manager: CLLocationManager
+    ) {
+        let verb = transition == .entered ? "entry" : "exit"
+        log("GeofencingManager: \(verb.capitalized) for region \(region.identifier)", prefix: "MIKA")
+
+        guard Date() >= ignoreEventsUntil else {
+            log("GeofencingManager: Ignoring \(verb) for \(region.identifier) during settling window", prefix: "MIKA")
+            return
+        }
+
+        pendingConfirmations[region.identifier] = transition
+        manager.requestState(for: region)
+    }
+
+    /// Runs `action` for a confirmed crossing, dropping a same-direction repeat
+    /// that lands within the cooldown (boundary flapping / duplicate events).
+    private func act(
+        on transition: RegionTransition,
+        region: String,
+        state: CLRegionState,
+        action: () -> Void
+    ) {
+        if transition == lastActedTransition,
+           Date().timeIntervalSince(lastActedTransitionAt) < transitionCooldown {
+            log("GeofencingManager: Debouncing repeat \(region) crossing within cooldown", prefix: "MIKA")
+            return
+        }
+
+        log("GeofencingManager: Confirmed crossing for \(region) (state=\(state.rawValue))", prefix: "MIKA")
+        lastActedTransition = transition
+        lastActedTransitionAt = Date()
+        action()
     }
 
     nonisolated func locationManager(

--- a/Shared/Managers/GeofencingManager.swift
+++ b/Shared/Managers/GeofencingManager.swift
@@ -375,14 +375,25 @@ extension GeofencingManager: CLLocationManagerDelegate {
             // Only act on states we explicitly requested to confirm an exit.
             guard self.pendingExitConfirmations.remove(region.identifier) != nil else { return }
 
-            if state == .outside {
-                log("GeofencingManager: Confirmed exit for \(region.identifier)", prefix: "MIKA")
-                self.handleRegionExit()
-            } else {
+            // `didExitRegion` already told us the device crossed the boundary;
+            // this confirmation only exists to discard GPS jitter that fires a
+            // spurious exit while the device is really still at the workplace.
+            // Trust the exit unless we get a *definitive* `.inside`. Treating
+            // `.unknown` (no fresh fix yet — common in the background, and on the
+            // short excursions typical of stepping out for a break) as "still
+            // inside" would silently drop the exit, so the break/clock-out would
+            // never happen.
+            if state == .inside {
                 log(
-                    "GeofencingManager: Ignoring unconfirmed exit for \(region.identifier) (state=\(state.rawValue))",
+                    "GeofencingManager: Ignoring exit for \(region.identifier); device is still inside",
                     prefix: "MIKA"
                 )
+            } else {
+                log(
+                    "GeofencingManager: Confirmed exit for \(region.identifier) (state=\(state.rawValue))",
+                    prefix: "MIKA"
+                )
+                self.handleRegionExit()
             }
         }
     }

--- a/Shared/Managers/GeofencingManager.swift
+++ b/Shared/Managers/GeofencingManager.swift
@@ -375,14 +375,9 @@ extension GeofencingManager: CLLocationManagerDelegate {
             // Only act on states we explicitly requested to confirm an exit.
             guard self.pendingExitConfirmations.remove(region.identifier) != nil else { return }
 
-            // `didExitRegion` already told us the device crossed the boundary;
-            // this confirmation only exists to discard GPS jitter that fires a
-            // spurious exit while the device is really still at the workplace.
-            // Trust the exit unless we get a *definitive* `.inside`. Treating
-            // `.unknown` (no fresh fix yet — common in the background, and on the
-            // short excursions typical of stepping out for a break) as "still
-            // inside" would silently drop the exit, so the break/clock-out would
-            // never happen.
+            // Trust the exit unless the device is definitively back inside.
+            // Dropping `.unknown` (no fresh fix yet, common in the background)
+            // would silently miss legitimate exits.
             if state == .inside {
                 log(
                     "GeofencingManager: Ignoring exit for \(region.identifier); device is still inside",

--- a/WorkingHour.xcodeproj/project.pbxproj
+++ b/WorkingHour.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -374,7 +374,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -530,7 +530,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour.Ushio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -558,7 +558,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.WorkingHour.Ushio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/WorkingHour/Views/Time Clock/TimeClockView.swift
+++ b/WorkingHour/Views/Time Clock/TimeClockView.swift
@@ -336,13 +336,6 @@ struct TimeClockView: View {
     func clockIn() {
         withAnimation(.smooth.speed(2.0)) {
             let newEntry = ClockEntry(.now)
-            if settingsManager.defaultBreakDuration > 0 {
-                let breakStart = Date.now
-                let breakEnd = breakStart.addingTimeInterval(settingsManager.defaultBreakDuration)
-                let newBreak = Break(start: breakStart, end: breakEnd)
-                newBreak.clockEntry = newEntry
-                modelContext.insert(newBreak)
-            }
             modelContext.insert(newEntry)
             startTimer()
             modelContext.processPendingChanges()


### PR DESCRIPTION
## Summary

Fixes the reported "break doesn't start when walking away from the geofence" bug, then hardens the location-based automation across **all four transitions** (clock-in, clock-out, break start, break end) and fixes a related regression that was auto-recording phantom breaks. Also bumps the app version to 1.1.1.

## Changes

### 1. Break now starts reliably when walking away
The exit-confirmation gate (added alongside the break feature in #21) only acted when `requestState` returned exactly `.outside`, silently dropping `.unknown` (no fresh background fix) and `.inside` results with no retry or fallback. Since `didExitRegion` fires only once per crossing, the exit — and the break — was lost. This hit breaks hardest because stepping out for a break is a *short* excursion, where `requestState` is far more likely to come back `.unknown`/`.inside`.

Now the OS exit is trusted unless `requestState` *definitively* reports `.inside` (the GPS-jitter case the confirmation was meant to catch).

### 2. Tightened geofence triggers (clock-in / clock-out / break start / break end)
- **Symmetric entry confirmation:** entries now go through the same `requestState` confirmation as exits, so jitter near the boundary can't cause a false auto clock-in or prematurely end a break.
- **Settling window covers entries too:** the post-(re)registration ignore window now suppresses spurious entries as well as exits, avoiding false clock-ins right after regions re-register on launch/settings changes.
- **Same-direction cooldown:** repeated crossings in the same direction within 60 s are debounced to stop clock-in/out and break churn while lingering at the boundary. Opposite directions (a genuine state change) always pass through.
- **Reliable ongoing-break lookup:** the active break is now found via `first(where: { $0.end == nil })` instead of `breakTimes.last`, which is unordered in SwiftData. Applied in clock-out, break-end, and the Live Activity session data.

### 3. Stop auto-recording a default break on every clock-in (regression fix)
PR #22 ("Remove auto-add break time toggle") removed the `autoAddBreakTime` flag but not the break-insertion it gated, leaving `if defaultBreakDuration > 0` — which, since the duration defaults to 3600 s, unconditionally wrote a 1-hour completed break at every auto **and** manual clock-in (e.g. a 09:50–10:50 break unrelated to any configured break window). Removed the pre-filled break insertion from both clock-in sites, restoring the pre-#22 default. Automatic breaks now come solely from the geofence break-window logic. The `defaultBreakDuration` setting is kept — it still drives the Live Activity's expected break-end projection.

### 4. Version bump
`MARKETING_VERSION` 1.1.0 → 1.1.1 (app + Ushio extension, Debug/Release).

## Out of scope
Multi-workplace overlap (exiting one region while still inside another is still treated as a departure) would require a fuller presence-model refactor and was intentionally left out.

## Note on existing data
This stops *new* phantom breaks; any 1-hour breaks already written by the buggy build remain in the database and would need manual cleanup (or a one-time migration).

## Testing
Logic-reviewed against the Core Location region state machine. Changes are confined to the geofence handlers, the two clock-in sites, and the break-lookup helpers; GPS-jitter suppression and the settling-window debounce are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)