### PR TITLE
Enforce minimum geofence radius for reliable detection

### DIFF
--- a/Shared/Data Models/Workplace.swift
+++ b/Shared/Data Models/Workplace.swift
@@ -10,6 +10,12 @@ import SwiftData
 
 @Model
 final class Workplace: Identifiable {
+
+    /// iOS region monitoring relies on coarse (cell/Wi-Fi) location in the
+    /// background, which typically has 100m+ accuracy. Radii smaller than
+    /// this are prone to missed, delayed, or spurious entry/exit events.
+    static let minimumReliableRadius: Double = 100.0
+
     var id: String = UUID().uuidString
     var name: String = ""
     var latitude: Double = 0.0

--- a/Shared/Data Models/Workplace.swift
+++ b/Shared/Data Models/Workplace.swift
@@ -11,9 +11,7 @@ import SwiftData
 @Model
 final class Workplace: Identifiable {
 
-    /// iOS region monitoring relies on coarse (cell/Wi-Fi) location in the
-    /// background, which typically has 100m+ accuracy. Radii smaller than
-    /// this are prone to missed, delayed, or spurious entry/exit events.
+    /// Below this, background location accuracy makes crossing detection unreliable.
     static let minimumReliableRadius: Double = 100.0
 
     var id: String = UUID().uuidString

--- a/Shared/Managers/GeofencingManager.swift
+++ b/Shared/Managers/GeofencingManager.swift
@@ -111,7 +111,10 @@ final class GeofencingManager: NSObject {
                         latitude: workplace.latitude,
                         longitude: workplace.longitude
                     ),
-                    radius: min(workplace.radius, locationManager.maximumRegionMonitoringDistance),
+                    radius: max(
+                        Workplace.minimumReliableRadius,
+                        min(workplace.radius, locationManager.maximumRegionMonitoringDistance)
+                    ),
                     identifier: workplace.id
                 )
                 region.notifyOnEntry = true

--- a/WorkingHour/Localizable.xcstrings
+++ b/WorkingHour/Localizable.xcstrings
@@ -2446,13 +2446,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The circle shows the geofence area. You will be clocked in when you enter this area and clocked out when you leave."
+            "value" : "The circle shows the geofence area. You will be clocked in when you enter this area and clocked out when you leave. A radius below 100m is not recommended, as background location accuracy may prevent reliable detection."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "円はジオフェンスの範囲を示しています。この範囲に入ると出勤し、離れると退勤します。"
+            "value" : "円はジオフェンスの範囲を示しています。この範囲に入ると出勤し、離れると退勤します。バックグラウンドでの位置情報の精度上、半径100m未満では正確に検出できない場合があるため推奨しません。"
           }
         }
       }

--- a/WorkingHour/Views/More/WorkplaceEditorView.swift
+++ b/WorkingHour/Views/More/WorkplaceEditorView.swift
@@ -98,7 +98,7 @@ struct WorkplaceEditorView: View {
                              + String(localized: "Workplace.Radius.Meters"))
                             .foregroundStyle(.secondary)
                     }
-                    Slider(value: $radius, in: 50...500, step: 25)
+                    Slider(value: $radius, in: Workplace.minimumReliableRadius...500, step: 25)
                         .tint(.accent)
                 }
                 .padding(.vertical, 4)
@@ -127,7 +127,7 @@ struct WorkplaceEditorView: View {
                     latitude: workplace.latitude,
                     longitude: workplace.longitude
                 )
-                radius = workplace.radius
+                radius = max(workplace.radius, Workplace.minimumReliableRadius)
             }
             updateCameraPosition()
         }


### PR DESCRIPTION
## Summary
- iOS background region monitoring uses coarse cell/Wi-Fi location with 100m+ typical accuracy, so a geofence radius smaller than that causes `didEnterRegion`/`didExitRegion` to be missed, delayed, or fired spuriously — this is what made small-radius geofencing appear broken.
- Added `Workplace.minimumReliableRadius` (100m) as the single source of truth for the floor.
- Raised the radius slider's minimum in `WorkplaceEditorView` from 50m to 100m, and clamp any previously-saved smaller values when loading the editor.
- Clamped the radius passed into `CLCircularRegion` in `GeofencingManager.startMonitoringWorkplaces()` to never go below the new minimum (in addition to the existing upper-bound clamp).
- Updated the editor's footer copy (English and Japanese) to explain why radii below 100m aren't recommended.

## Test plan
- [ ] Build and run on a physical device (region monitoring doesn't behave meaningfully in the simulator)
- [ ] Add/edit a workplace and confirm the radius slider no longer allows values below 100m
- [ ] Open an existing workplace previously saved with a radius below 100m and confirm it loads clamped to 100m without a Slider range crash
- [ ] Verify entry/exit auto clock-in/out behavior with a 100m+ radius geofence


---
_Generated by [Claude Code](https://claude.ai/code/session_018dwrLjEafFRVtHSnPzw8aX)_