### PR TITLE
Support Apple Watch Live Activities properly

### DIFF
--- a/Ushio/Live Activity/LiveActivityView.swift
+++ b/Ushio/Live Activity/LiveActivityView.swift
@@ -10,6 +10,8 @@ import WidgetKit
 import SwiftUI
 
 struct LiveActivityView: View {
+    @Environment(\.activityFamily) private var activityFamily
+
     let context: ActivityViewContext<UshioAttributes>
 
     /// The moment the current break exceeds the configured break duration,
@@ -24,6 +26,18 @@ struct LiveActivityView: View {
     }
 
     var body: some View {
+        switch activityFamily {
+        case .small:
+            // Compact layout for the Smart Stack on a paired Apple Watch.
+            SmallLiveActivityView(context: context)
+        case .medium:
+            mediumContent
+        @unknown default:
+            mediumContent
+        }
+    }
+
+    private var mediumContent: some View {
         VStack(spacing: 6.0) {
             // Clock in/out times
             HStack(alignment: .center, spacing: 12.0) {

--- a/Ushio/Live Activity/SmallLiveActivityView.swift
+++ b/Ushio/Live Activity/SmallLiveActivityView.swift
@@ -1,0 +1,198 @@
+//
+//  SmallLiveActivityView.swift
+//  Ushio
+//
+//  Created by シン・ジャスティン on 2026/07/02.
+//
+
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+/// Compact presentation of the live activity for the small activity family,
+/// shown in the Smart Stack on a paired Apple Watch. Follows the watchOS
+/// guidance of staying glanceable with at most one control.
+struct SmallLiveActivityView: View {
+    let context: ActivityViewContext<UshioAttributes>
+
+    /// The moment the current break exceeds the configured break duration,
+    /// or `nil` when not on a break or no break duration is configured.
+    private var breakEndDate: Date? {
+        guard context.state.isOnBreak,
+              context.state.defaultBreakDuration > 0,
+              let breakStartTime = context.state.breakStartTime else {
+            return nil
+        }
+        return breakStartTime.addingTimeInterval(context.state.defaultBreakDuration)
+    }
+
+    private var isExceedingBreak: Bool {
+        guard let breakEndDate else { return false }
+        return Date.now >= breakEndDate
+    }
+
+    /// The moment the standard working hours elapse, accounting for breaks.
+    private var endWorkDate: Date {
+        context.state.clockInTime
+            .addingTimeInterval(context.state.totalBreakTime)
+            .addingTimeInterval(context.state.standardWorkingHours)
+    }
+
+    private var statusTint: Color {
+        guard context.state.isOnBreak else { return .blue }
+        return isExceedingBreak ? .red : .orange
+    }
+
+    var body: some View {
+        if let clockOutTime = context.state.clockOutTime {
+            clockedOutContent(clockOutTime)
+        } else {
+            activeContent
+        }
+    }
+
+    private var activeContent: some View {
+        HStack(alignment: .center, spacing: 8.0) {
+            VStack(alignment: .leading, spacing: 2.0) {
+                HStack(spacing: 4.0) {
+                    Image(systemName: context.state.isOnBreak ?
+                          "cup.and.heat.waves.fill" : "clock.fill")
+                    Text(context.state.isOnBreak ?
+                         "TimeClock.Break.OnBreak" : "TimeClock.Work.Working")
+                }
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(statusTint)
+
+                if context.state.isOnBreak,
+                   let breakStartTime = context.state.breakStartTime {
+                    Text(breakStartTime, style: .relative)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundStyle(isExceedingBreak ? .red : .primary)
+                } else {
+                    Text(context.state.clockInTime, style: .relative)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                }
+
+                detailRow
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if context.isStale {
+                // The stale prompt does not fit the Smart Stack, so a
+                // refresh indicator takes the control's place instead.
+                Image(systemName: "exclamationmark.arrow.circlepath")
+                    .font(.body)
+                    .foregroundStyle(.blue)
+            } else if context.state.isOnBreak {
+                Button(intent: EndBreakIntent(entryId: context.attributes.entryId)) {
+                    Image(systemName: "arrowshape.turn.up.backward.badge.clock.fill")
+                        .font(.body)
+                        .fontWeight(.semibold)
+                }
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.circle)
+                .tint(.red)
+            } else {
+                Button(intent: StartBreakIntent(entryId: context.attributes.entryId)) {
+                    Image(systemName: "cup.and.heat.waves.fill")
+                        .font(.body)
+                        .fontWeight(.semibold)
+                }
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.circle)
+                .tint(.orange)
+            }
+        }
+        .padding(8.0)
+        .background {
+            if context.state.isOnBreak {
+                Color.orange.opacity(0.2)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+    }
+
+    /// Bottom line of the active layout: overtime warnings when a threshold
+    /// has been crossed, the clock-in time otherwise.
+    @ViewBuilder
+    private var detailRow: some View {
+        if context.state.isOnBreak {
+            if isExceedingBreak, let breakEndDate {
+                HStack(spacing: 3.0) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                    Text("Shared.BreakOvertime")
+                        .fontWeight(.semibold)
+                    Text(breakEndDate, style: .timer)
+                }
+                .font(.caption2)
+                .foregroundStyle(.red)
+            } else {
+                clockInRow
+            }
+        } else if Date.now >= endWorkDate {
+            HStack(spacing: 3.0) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                Text("Shared.Overtime")
+                    .fontWeight(.semibold)
+                Text(endWorkDate, style: .timer)
+            }
+            .font(.caption2)
+            .foregroundStyle(.red)
+        } else {
+            HStack(spacing: 3.0) {
+                Image(systemName: "clock.badge.checkmark.fill")
+                Text("Shared.Remaining")
+                    .fontWeight(.semibold)
+                Text(endWorkDate, style: .timer)
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private var clockInRow: some View {
+        HStack(spacing: 3.0) {
+            Text("TimeClock.Work.ClockIn")
+                .fontWeight(.semibold)
+            Text(context.state.clockInTime, style: .time)
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+
+    private func clockedOutContent(_ clockOutTime: Date) -> some View {
+        VStack(alignment: .leading, spacing: 2.0) {
+            Text("Timesheet.TotalTimeWorked")
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            let totalTime = clockOutTime.timeIntervalSince(
+                context.state.clockInTime
+            ) - context.state.totalBreakTime
+            Text(formatTimeInterval(totalTime))
+                .font(.title3)
+                .fontWeight(.bold)
+
+            HStack(spacing: 4.0) {
+                Text(context.state.clockInTime, style: .time)
+                Image(systemName: "arrow.right")
+                Text(clockOutTime, style: .time)
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8.0)
+    }
+
+    private func formatTimeInterval(_ interval: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: interval) ?? ""
+    }
+}

--- a/Ushio/Live Activity/Widget.swift
+++ b/Ushio/Live Activity/Widget.swift
@@ -177,5 +177,8 @@ struct UshioLiveActivity: Widget {
             }
             .keylineTint(sessionTint(context.state))
         }
+        // Opts into the Smart Stack on a paired Apple Watch, which renders
+        // the small activity family instead of recomposited compact views.
+        .supplementalActivityFamilies([.small])
     }
 }


### PR DESCRIPTION
## Summary

Until now the Live Activity had no watchOS support, so watchOS 11+ falls back to recompositing the Dynamic Island compact leading/trailing views in the Smart Stack — a tiny clock icon and progress ring with no useful detail. This PR opts into the small supplemental activity family and provides a purpose-built layout for the Apple Watch Smart Stack.

## Changes

- **`Ushio/Live Activity/Widget.swift`**: Added `.supplementalActivityFamilies([.small])` to the `ActivityConfiguration` so watchOS renders the activity's content view in the Smart Stack instead of the recomposited compact views.
- **`Ushio/Live Activity/LiveActivityView.swift`**: Reads `@Environment(\.activityFamily)` and switches between the existing lock-screen layout (`.medium`) and the new watch layout (`.small`).
- **`Ushio/Live Activity/SmallLiveActivityView.swift`** (new): Compact Smart Stack layout following Apple's watchOS Live Activity design guidance (glanceable, one control max):
  - Status line (Working / On Break) with the session tint, plus the elapsed work or break timer.
  - Detail line showing remaining time, or a red overtime / break-overtime warning once the respective threshold is crossed; the clock-in time while on a break within its window.
  - A single contextual circular control: start break while working, end break while on a break (App Intent taps are forwarded to the paired iPhone).
  - When the activity goes stale, a refresh indicator replaces the control (the full stale prompt doesn't fit the Smart Stack).
  - Clocked-out state shows the total time worked and the clock-in → clock-out range.

All strings reuse existing `Localizable.xcstrings` keys (en/ja), and the new file is picked up automatically by the Ushio target's file-system-synchronized group, so no project file changes were needed.

## Testing

Not built/run — this environment has no Xcode toolchain. Please verify on device/simulator: run a session on iPhone with a paired Apple Watch (watchOS 11+) and check the Smart Stack presentation for the working, on-break, break-overtime, overtime, stale, and clocked-out states, and that the break button toggles the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkaRkgMBuJYcSQAKeFAMPq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkaRkgMBuJYcSQAKeFAMPq)_